### PR TITLE
HTTPError.message is not a thing

### DIFF
--- a/sprockets/clients/dynamodb/__init__.py
+++ b/sprockets/clients/dynamodb/__init__.py
@@ -4,7 +4,7 @@ except ImportError as error:
     def DynamoDB(*args, **kwargs):
         raise error
 
-version_info = (0, 2, 0)
+version_info = (0, 2, 1)
 __version__ = '.'.join(str(v) for v in version_info)
 
 # Response constants

--- a/sprockets/clients/dynamodb/connector.py
+++ b/sprockets/clients/dynamodb/connector.py
@@ -104,8 +104,9 @@ class DynamoDB(object):
                 if http_err.code == 599:
                     future.set_exception(exceptions.TimeoutException())
                 else:
+
                     future.set_exception(
-                        exceptions.RequestException(http_err.message))
+                        exceptions.RequestException(http_err.response.body))
             except Exception as exception:
                 future.set_exception(exception)
             else:
@@ -126,7 +127,8 @@ class DynamoDB(object):
             if err.code == 599:
                 future.set_exception(exceptions.TimeoutException())
             else:
-                future.set_exception(exceptions.RequestException(err.message))
+                future.set_exception(
+                    exceptions.RequestException(err.response.body))
         else:
             ioloop.IOLoop.current().add_future(aws_response, handle_response)
         return future

--- a/sprockets/clients/dynamodb/connector.py
+++ b/sprockets/clients/dynamodb/connector.py
@@ -104,9 +104,10 @@ class DynamoDB(object):
                 if http_err.code == 599:
                     future.set_exception(exceptions.TimeoutException())
                 else:
-
-                    future.set_exception(
-                        exceptions.RequestException(http_err.response.body))
+                    response_reason = err.code
+                    if err.response and hasattr(err.response, 'body'):
+                        response_reason = err.response.body
+                    future.set_exception(response_reason)
             except Exception as exception:
                 future.set_exception(exception)
             else:
@@ -127,8 +128,10 @@ class DynamoDB(object):
             if err.code == 599:
                 future.set_exception(exceptions.TimeoutException())
             else:
-                future.set_exception(
-                    exceptions.RequestException(err.response.body))
+                reason = err.code
+                if err.response and hasattr(err.response, 'body'):
+                    reason = err.response.body
+                future.set_exception(reason)
         else:
             ioloop.IOLoop.current().add_future(aws_response, handle_response)
         return future

--- a/sprockets/clients/dynamodb/connector.py
+++ b/sprockets/clients/dynamodb/connector.py
@@ -104,9 +104,10 @@ class DynamoDB(object):
                 if http_err.code == 599:
                     future.set_exception(exceptions.TimeoutException())
                 else:
-                    response_reason = err.code
-                    if err.response and hasattr(err.response, 'body'):
-                        response_reason = err.response.body
+                    response_reason = http_err.code
+                    if http_err.response and \
+                            hasattr(http_err.response, 'body'):
+                        response_reason = http_err.response.body
                     future.set_exception(response_reason)
             except Exception as exception:
                 future.set_exception(exception)

--- a/sprockets/clients/dynamodb/connector.py
+++ b/sprockets/clients/dynamodb/connector.py
@@ -104,11 +104,12 @@ class DynamoDB(object):
                 if http_err.code == 599:
                     future.set_exception(exceptions.TimeoutException())
                 else:
-                    response_reason = http_err.code
+                    response_reason = str(http_err.code)
                     if http_err.response and \
                             hasattr(http_err.response, 'body'):
                         response_reason = http_err.response.body
-                    future.set_exception(response_reason)
+                    future.set_exception(
+                        exceptions.RequestException(response_reason))
             except Exception as exception:
                 future.set_exception(exception)
             else:
@@ -129,10 +130,11 @@ class DynamoDB(object):
             if err.code == 599:
                 future.set_exception(exceptions.TimeoutException())
             else:
-                reason = err.code
+                reason = str(err.code)
                 if err.response and hasattr(err.response, 'body'):
                     reason = err.response.body
-                future.set_exception(reason)
+                future.set_exception(exceptions.RequestException(reason))
+
         else:
             ioloop.IOLoop.current().add_future(aws_response, handle_response)
         return future


### PR DESCRIPTION
Fixes `HTTPError' object has no attribute 'message'` attribute exceptions
